### PR TITLE
Altering way DNS64 container is configured.

### DIFF
--- a/config.go
+++ b/config.go
@@ -116,12 +116,8 @@ const (
 
 	// DNS64Name name of the DNS64 server
 	DNS64Name = "bind9"
-	// DNS64BaseArea root of where DNS64 directory tree exists
-	DNS64BaseArea = "bind9"
-	// DNS64ConfArea subdirectory for config files
-	DNS64ConfArea = "conf"
-	// DNS64CacheArea subdirectory for runtime cache files
-	DNS64CacheArea = "cache"
+	// DNS64Volume name of volume holding DNS64 configuration
+	DNS64Volume = "volume-bind9"
 	// DNS64NamedConf main configuration file
 	DNS64NamedConf = "named.conf"
 

--- a/docker.go
+++ b/docker.go
@@ -3,19 +3,29 @@ package lazyjack
 import (
 	"fmt"
 	"os/exec"
-	"path/filepath"
 	"strings"
 
 	"github.com/golang/glog"
 )
 
+// DefaultDockerCommand command used for docker
+const DefaultDockerCommand = "docker"
+
 // Docker represents a concrete hypervisor implementation.
-type Docker struct{}
+type Docker struct {
+	Command string
+}
+
+// BuildResourceStateArgs constructs arg to obtain resource state
+func BuildResourceStateArgs(resource string) []string {
+	return []string{"inspect", resource}
+}
 
 // ResourceState method obtains the state of the resource, which can be
 // not present, existing, or running (for container resources).
 func (d *Docker) ResourceState(r string) string {
-	output, err := DoCommand(r, []string{"inspect", r})
+	args := BuildResourceStateArgs(r)
+	output, err := d.DoCommand("Resource State", args)
 	if err != nil {
 		glog.V(4).Infof("No %q resource", r)
 		return ResourceNotPresent
@@ -30,22 +40,21 @@ func (d *Docker) ResourceState(r string) string {
 
 // DoCommand performs a docker command, collecting and returning output.
 // TODO: Perform in a separate go-routine with a timeout, and abort handling.
-func DoCommand(name string, args []string) (string, error) {
+func (d *Docker) DoCommand(name string, args []string) (string, error) {
 	glog.V(4).Infof("Invoking: docker %s", strings.Join(args, " "))
 	cmd := args[0]
-	c := exec.Command("docker", args...)
+	c := exec.Command(d.Command, args...)
 	output, err := c.Output()
 	if err != nil {
 		return "", fmt.Errorf("docker %q failed for %q: %v (%s)", cmd, name, err, output)
 	}
-	glog.V(4).Infof("Docker %q successful for %q", cmd, name)
+	glog.V(4).Infof("Docker %q operation successful", name)
 	return string(output), nil
 }
 
 // BuildRunArgsForDNS64 constructs docker command to start DNS64 container.
 func BuildRunArgsForDNS64(c *Config) []string {
-	conf := filepath.Join(c.General.WorkArea, DNS64BaseArea, DNS64ConfArea, DNS64NamedConf)
-	volumeMap := fmt.Sprintf("%s:/etc/bind/named.conf", conf)
+	volumeMap := fmt.Sprintf("%s:/etc/bind/", DNS64Volume)
 	cmdList := []string{
 		"run", "-d", "--name", DNS64Name, "--hostname", DNS64Name, "--label", "lazyjack",
 		"--privileged=true", "--ip6", c.DNS64.ServerIP, "--dns", c.DNS64.ServerIP,
@@ -66,7 +75,7 @@ func BuildGetInterfaceArgs(container, ifName string) []string {
 // IP addresses.
 func (d *Docker) GetInterfaceConfig(name, ifName string) (string, error) {
 	args := BuildGetInterfaceArgs(name, ifName)
-	return DoCommand("Get I/F config", args)
+	return d.DoCommand("Get I/F config", args)
 }
 
 // BuildV4AddrDelArgs constructs arguments for deleting an IPv4 address
@@ -79,7 +88,7 @@ func BuildV4AddrDelArgs(container, ip string) []string {
 // the container's eth0 interface.
 func (d *Docker) DeleteV4Address(container, ip string) error {
 	args := BuildV4AddrDelArgs(container, ip)
-	_, err := DoCommand("Delete IPv4 addr", args)
+	_, err := d.DoCommand("Delete IPv4 addr", args)
 	return err
 }
 
@@ -93,14 +102,19 @@ func BuildAddRouteArgs(container, dest, via string) []string {
 // AddV6Route performs docker command to add an IPv6 route.
 func (d *Docker) AddV6Route(container, dest, via string) error {
 	args := BuildAddRouteArgs(container, dest, via)
-	_, err := DoCommand("Add IPv6 route", args)
+	_, err := d.DoCommand("Add IPv6 route", args)
 	return err
 }
 
-// DeleteContainer performs docker command to remove a container.
+// BuildDeleteContainerArgs create arguments for the docker command to delete container
+func BuildDeleteContainerArgs(name string) []string {
+	return []string{"rm", "-f", name}
+}
+
+// DeleteContainer constructs arguments to remove a container.
 func (d *Docker) DeleteContainer(name string) error {
-	args := []string{"rm", "-f", name}
-	_, err := DoCommand(name, args)
+	args := BuildDeleteContainerArgs(name)
+	_, err := d.DoCommand("Delete container", args)
 	return err
 }
 
@@ -123,16 +137,16 @@ func BuildRunArgsForNAT64(c *Config) []string {
 
 // RunContainer performs docker command to run a container.
 func (d *Docker) RunContainer(name string, args []string) error {
-	_, err := DoCommand(name, args)
+	_, err := d.DoCommand("Run container", args)
 	return err
 }
 
 // BuildCreateNetArgsFor constructs arguments to create a docker network.
-func BuildCreateNetArgsFor(name, cidr, v4cidr, gw string) []string {
+func BuildCreateNetArgsFor(name, cidr, v4cidr, gwPrefix string) []string {
 	args := []string{"network", "create", "--ipv6"}
 	subnetOption := fmt.Sprintf("--subnet=\"%s\"", cidr)
 	v4SubnetOption := fmt.Sprintf("--subnet=%s", v4cidr)
-	gwOption := fmt.Sprintf("--gateway=\"%s1\"", gw)
+	gwOption := fmt.Sprintf("--gateway=\"%s1\"", gwPrefix)
 	args = append(args, subnetOption, v4SubnetOption, gwOption, name)
 	return args
 }
@@ -140,7 +154,7 @@ func BuildCreateNetArgsFor(name, cidr, v4cidr, gw string) []string {
 // CreateNetwork performs docker command to create a network.
 func (d *Docker) CreateNetwork(name, cidr, v4cidr, gw string) error {
 	args := BuildCreateNetArgsFor(name, cidr, v4cidr, gw)
-	_, err := DoCommand(name, args)
+	_, err := d.DoCommand("Create network", args)
 	return err
 }
 
@@ -152,6 +166,45 @@ func BuildDeleteNetArgsFor(name string) []string {
 // DeleteNetwork performs docker command to delete a network.
 func (d *Docker) DeleteNetwork(name string) error {
 	args := BuildDeleteNetArgsFor(name)
-	_, err := DoCommand("SupportNetName", args)
+	_, err := d.DoCommand("Delete network", args)
 	return err
+}
+
+// BuildCreateVolumeArgs constructs arguments to create a volume
+func BuildCreateVolumeArgs(name string) []string {
+	return []string{"volume", "create", name}
+}
+
+// CreateVolume creates a new docker volume
+func (d *Docker) CreateVolume(name string) error {
+	args := BuildCreateVolumeArgs(name)
+	_, err := d.DoCommand("Volume create", args)
+	return err
+}
+
+// BuildDeleteVolumeArgs constructs arguments to delete a volume
+func BuildDeleteVolumeArgs(name string) []string {
+	return []string{"volume", "rm", "-f", name}
+}
+
+// DeleteVolume force deletes a docker volume. No error occurs, if volume doesn't exist.
+func (d *Docker) DeleteVolume(name string) error {
+	args := BuildDeleteVolumeArgs(name)
+	_, err := d.DoCommand("Volume delete", args)
+	return err
+}
+
+// BuildCreateVolumeArgs constructs arguments to create a volume
+func BuildInspectVolumeArgs(name string) []string {
+	return []string{"volume", "inspect", "-f", "\"{{json .Mountpoint}}\"", name}
+}
+
+// GetVolumeMountPoint obtains the mount point so that files can be deposited from host.
+func (d *Docker) GetVolumeMountPoint(name string) (string, error) {
+	args := BuildInspectVolumeArgs(name)
+	mountPoint, err := d.DoCommand("Volume inspect", args)
+	if err != nil {
+		return "", err
+	}
+	return strings.Trim(mountPoint, "\"\n"), nil
 }

--- a/docker_test.go
+++ b/docker_test.go
@@ -1,11 +1,58 @@
 package lazyjack_test
 
 import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/pmichali/lazyjack"
 )
+
+func TestBuildResourceStateArgs(t *testing.T) {
+	list := lazyjack.BuildResourceStateArgs("my-network")
+	actual := strings.Join(list, " ")
+	expected := "inspect my-network"
+	if actual != expected {
+		t.Fatalf("FAILED: Building resource state args. Expected %q, got %q", expected, actual)
+	}
+}
+
+func TestResourceState(t *testing.T) {
+	var testCases = []struct {
+		name     string
+		resource string
+		cmd      string
+		expected string
+	}{
+		{
+			name:     "resource exists",
+			resource: "host", // Should be there on system with docker installed
+			cmd:      lazyjack.DefaultDockerCommand,
+			expected: lazyjack.ResourceExists,
+		},
+		{
+			name:     "resource running",
+			resource: "\"Running\": true", // Bogus name so that output has expected string when doing echo, instead of docker command
+			cmd:      "echo",
+			expected: lazyjack.ResourceRunning,
+		},
+		{
+			name:     "resource doesn't exists",
+			resource: "no-such-resource",
+			cmd:      lazyjack.DefaultDockerCommand,
+			expected: lazyjack.ResourceNotPresent,
+		},
+	}
+	for _, tc := range testCases {
+		d := lazyjack.Docker{Command: tc.cmd}
+		actual := d.ResourceState(tc.resource)
+		if actual != tc.expected {
+			t.Fatalf("FAILED: [%s] resource state mismatch. Expected %q, got %q", tc.name, tc.expected, actual)
+		}
+	}
+}
 
 func TestBuildDockerArgsForDNS64(t *testing.T) {
 	c := &lazyjack.Config{
@@ -17,7 +64,7 @@ func TestBuildDockerArgsForDNS64(t *testing.T) {
 
 	list := lazyjack.BuildRunArgsForDNS64(c)
 	actual := strings.Join(list, " ")
-	expected := "run -d --name bind9 --hostname bind9 --label lazyjack --privileged=true --ip6 2001:db8::100 --dns 2001:db8::100 --sysctl net.ipv6.conf.all.disable_ipv6=0 --sysctl net.ipv6.conf.all.forwarding=1 -v /tmp/lazyjack/bind9/conf/named.conf:/etc/bind/named.conf --net support_net resystit/bind9:latest"
+	expected := "run -d --name bind9 --hostname bind9 --label lazyjack --privileged=true --ip6 2001:db8::100 --dns 2001:db8::100 --sysctl net.ipv6.conf.all.disable_ipv6=0 --sysctl net.ipv6.conf.all.forwarding=1 -v volume-bind9:/etc/bind/ --net support_net resystit/bind9:latest"
 	if actual != expected {
 		t.Fatalf("FAILED: Building docker run args for DNS64.\nExpected: %q\n  Actual: %q", expected, actual)
 	}
@@ -32,12 +79,28 @@ func TestBuildCreateSupportNetArgs(t *testing.T) {
 	}
 }
 
+func TestCreateNetwork(t *testing.T) {
+	d := lazyjack.Docker{Command: "echo"}
+	err := d.CreateNetwork("my-network", "2001:db8::/64", "10.20.0.0/16", "2001:db8::")
+	if err != nil {
+		t.Fatalf("FAILED: Expected to be able to create network")
+	}
+}
+
 func TestBuildDeleteNetArgs(t *testing.T) {
 	list := lazyjack.BuildDeleteNetArgsFor(lazyjack.SupportNetName)
 	actual := strings.Join(list, " ")
 	expected := "network rm support_net"
 	if actual != expected {
 		t.Fatalf("FAILED: Building support net delete args. Expected %q, got %q", expected, actual)
+	}
+}
+
+func TestDeleteNetwork(t *testing.T) {
+	d := lazyjack.Docker{Command: "echo"}
+	err := d.DeleteNetwork("my-network")
+	if err != nil {
+		t.Fatalf("FAILED: Expected to be able to delete network")
 	}
 }
 
@@ -50,6 +113,18 @@ func TestBuildGetInterfaceArgs(t *testing.T) {
 	}
 }
 
+func TestGetInterfaceConfig(t *testing.T) {
+	d := lazyjack.Docker{Command: "echo"}
+	actual, err := d.GetInterfaceConfig("my-container", "eth0")
+	if err != nil {
+		t.Fatalf("FAILED: Expected to be able to get interface config")
+	}
+	expected := "exec my-container ip addr list eth0\n"
+	if actual != expected {
+		t.Fatalf("FAILED: Get I/F config. Expected %q, got %q", expected, actual)
+	}
+}
+
 func TestBuildAddrDeleteArgs(t *testing.T) {
 	list := lazyjack.BuildV4AddrDelArgs("bind9", "172.18.0.2/16")
 	actual := strings.Join(list, " ")
@@ -59,12 +134,45 @@ func TestBuildAddrDeleteArgs(t *testing.T) {
 	}
 }
 
+func TestDeleteV4Address(t *testing.T) {
+	d := lazyjack.Docker{Command: "echo"}
+	err := d.DeleteV4Address("my-container", "192.168.0.5/24")
+	if err != nil {
+		t.Fatalf("FAILED: Expected to be able to delete V4 IP")
+	}
+}
+
 func TestBuildAddRouteForDNS64Args(t *testing.T) {
 	list := lazyjack.BuildAddRouteArgs("bind9", "fd00:10:64:ff9b::/96", "fd00:10::200")
 	actual := strings.Join(list, " ")
 	expected := "exec bind9 ip -6 route add fd00:10:64:ff9b::/96 via fd00:10::200"
 	if actual != expected {
 		t.Fatalf("FAILED: Building add route args. Expected %q, got %q", expected, actual)
+	}
+}
+
+func TestAddV6Route(t *testing.T) {
+	d := lazyjack.Docker{Command: "echo"}
+	err := d.AddV6Route("my-container", "2001:db8::/64", "2001:db8::200")
+	if err != nil {
+		t.Fatalf("FAILED: Expected to be able to add route")
+	}
+}
+
+func TestBuildDeleteContainerArgs(t *testing.T) {
+	list := lazyjack.BuildDeleteContainerArgs("bind9")
+	actual := strings.Join(list, " ")
+	expected := "rm -f bind9"
+	if actual != expected {
+		t.Fatalf("FAILED: Building delete container args. Expected %q, got %q", expected, actual)
+	}
+}
+
+func TestDeleteContainer(t *testing.T) {
+	d := lazyjack.Docker{Command: "echo"}
+	err := d.DeleteContainer("my-container")
+	if err != nil {
+		t.Fatalf("FAILED: Expected to be able to delete container")
 	}
 }
 
@@ -88,5 +196,88 @@ func TestBuildDockerArgsForNAT64(t *testing.T) {
 	expected := "run -d --name tayga --hostname tayga --label lazyjack --privileged=true --ip 172.18.0.200 --ip6 fd00:10::200 --dns 8.8.8.8 --dns fd00:10::100 --sysctl net.ipv6.conf.all.disable_ipv6=0 --sysctl net.ipv6.conf.all.forwarding=1 -e TAYGA_CONF_PREFIX=fd00:10:64:ff9b::/96 -e TAYGA_CONF_IPV4_ADDR=172.18.0.200 -e TAYGA_CONF_DYNAMIC_POOL=172.18.0.128/25 --net support_net danehans/tayga:latest"
 	if actual != expected {
 		t.Fatalf("FAILED: Building docker run args for NAT64.\nExpected: %q\n  Actual: %q", expected, actual)
+	}
+}
+
+func TestRunContainer(t *testing.T) {
+	d := lazyjack.Docker{Command: "echo"}
+	err := d.RunContainer("my-container", []string{"arg1", "arg2"})
+	if err != nil {
+		t.Fatalf("FAILED: Expected to be able to run container")
+	}
+}
+
+func TestBuildCreateVolumeArgs(t *testing.T) {
+	list := lazyjack.BuildCreateVolumeArgs("volume-dummy")
+	actual := strings.Join(list, " ")
+	expected := "volume create volume-dummy"
+	if actual != expected {
+		t.Fatalf("FAILED: Building create volume args. Expected %q, got %q", expected, actual)
+	}
+}
+
+func TestCreateVolume(t *testing.T) {
+	d := lazyjack.Docker{Command: "echo"}
+	err := d.CreateVolume("my-volume")
+	if err != nil {
+		t.Fatalf("FAILED: Expected to be able to create volume")
+	}
+}
+
+func TestBuildDeleteVolumeArgs(t *testing.T) {
+	list := lazyjack.BuildDeleteVolumeArgs("volume-dummy")
+	actual := strings.Join(list, " ")
+	expected := "volume rm -f volume-dummy"
+	if actual != expected {
+		t.Fatalf("FAILED: Building delete volume args. Expected %q, got %q", expected, actual)
+	}
+}
+
+func TestDeleteVolume(t *testing.T) {
+	d := lazyjack.Docker{Command: "echo"}
+	err := d.DeleteVolume("my-volume")
+	if err != nil {
+		t.Fatalf("FAILED: Expected to be able to delete volume")
+	}
+}
+
+func TestBuildInspectVolumeArgs(t *testing.T) {
+	list := lazyjack.BuildInspectVolumeArgs("volume-dummy")
+	actual := strings.Join(list, " ")
+	expected := "volume inspect -f \"{{json .Mountpoint}}\" volume-dummy"
+	if actual != expected {
+		t.Fatalf("FAILED: Building inspect volume args. Expected %q, got %q", expected, actual)
+	}
+}
+
+func TestGetVolumeMountPoint(t *testing.T) {
+	// Need to do a real docker command here, because the result is post processed some
+	d := lazyjack.Docker{Command: lazyjack.DefaultDockerCommand}
+	randBytes := make([]byte, 16)
+	rand.Read(randBytes)
+	tempName := "test" + hex.EncodeToString(randBytes)
+	d.DoCommand("create dummy volume", []string{"volume", "create", tempName})
+	defer d.DoCommand("delete dummy volume", []string{"volume", "rm", "-f", tempName})
+
+	actual, err := d.GetVolumeMountPoint(tempName)
+	if err != nil {
+		t.Fatalf("FAILED: Expected to be able to get volume mount point")
+	}
+	expected := fmt.Sprintf("/var/lib/docker/volumes/%s/_data", tempName)
+	if actual != expected {
+		t.Fatalf("FAILED: Getting volume mount point. Expected %q, got %q", expected, actual)
+	}
+}
+
+func TestFailedGetVolumeMountPoint(t *testing.T) {
+	d := lazyjack.Docker{Command: lazyjack.DefaultDockerCommand}
+
+	_, err := d.GetVolumeMountPoint("no-such-volume-exists")
+	if err == nil {
+		t.Fatalf("FAILED: Expected not to be able to get volume mount point")
+	}
+	expected := "docker \"volume\" failed for \"Volume inspect\": exit status 1"
+	if !strings.HasPrefix(err.Error(), expected) {
+		t.Fatalf("FAILED: Expected reason to be  %q, got %q", expected, err.Error())
 	}
 }

--- a/hypervisor.go
+++ b/hypervisor.go
@@ -10,4 +10,7 @@ type Hypervisor interface {
 	GetInterfaceConfig(string, string) (string, error)
 	DeleteV4Address(string, string) error
 	AddV6Route(string, string, string) error
+	CreateVolume(string) error
+	DeleteVolume(string) error
+	GetVolumeMountPoint(string) (string, error)
 }

--- a/hypervisor_test.go
+++ b/hypervisor_test.go
@@ -18,6 +18,11 @@ type MockHypervisor struct {
 	simAddRouteFail        bool
 	simRouteExists         bool
 	simCreateNetFail       bool
+	simCreateVolumeFail    bool
+	simDeleteVolumeFail    bool
+	simInspectVolumeFail   bool
+	simBadVolumeInfo       bool
+	mountPoint             string
 }
 
 func (mh *MockHypervisor) ResourceState(r string) string {
@@ -96,4 +101,28 @@ func (mh *MockHypervisor) CreateNetwork(name, cidr, v4cidr, gw string) error {
 		return fmt.Errorf("mock fail create of network")
 	}
 	return nil
+}
+
+func (mh *MockHypervisor) CreateVolume(name string) error {
+	if mh.simCreateVolumeFail {
+		return fmt.Errorf("mock fail create of volume")
+	}
+	return nil
+}
+
+func (mh *MockHypervisor) DeleteVolume(name string) error {
+	if mh.simDeleteVolumeFail {
+		return fmt.Errorf("mock fail delete of volume")
+	}
+	return nil
+}
+
+func (mh *MockHypervisor) GetVolumeMountPoint(name string) (string, error) {
+	if mh.simInspectVolumeFail {
+		return "", fmt.Errorf("mock fail inspect of volume")
+	}
+	if mh.simBadVolumeInfo {
+		return "/tmp/volume-mount-point-failure", nil
+	}
+	return mh.mountPoint, nil
 }

--- a/validate.go
+++ b/validate.go
@@ -377,7 +377,7 @@ func SetupHandles(c *Config) error {
 		return fmt.Errorf("internal Error - unable to access networking package: %v", err)
 	}
 	c.General.NetMgr = NetMgr{Server: NetLink{h: handle}}
-	c.General.Hyper = &Docker{}
+	c.General.Hyper = &Docker{Command: DefaultDockerCommand}
 	return nil
 }
 


### PR DESCRIPTION
Instead of bind-mounting a local file to provide config to the DNS64
container, a volume is created and the container mounts the volume.
This gives better security on access to the mounted area.

Updating coverage in docker area. At 90.2%, including the changes
made for this enhancement.

Fixes issue: #1